### PR TITLE
Remove active class

### DIFF
--- a/kwc-nav-button.html
+++ b/kwc-nav-button.html
@@ -15,6 +15,11 @@ Display an outline button item in the `kwc-nav`
         <style>
             :host {
                 display: inline-block;
+                /**
+                 * This makes sure that it has a width before the slotted
+                 * content is loaded when there is no icon.
+                 */
+                min-width: 1px;
             }
             .nav-item ::slotted(*) {
                 text-decoration: inherit;

--- a/kwc-nav-button.html
+++ b/kwc-nav-button.html
@@ -21,6 +21,8 @@ Display an outline button item in the `kwc-nav`
                  */
                 min-width: 1px;
             }
+
+            /* SLOTTED CONTENT */
             .nav-item ::slotted(*) {
                 text-decoration: inherit;
                 font-family: inherit;
@@ -35,6 +37,8 @@ Display an outline button item in the `kwc-nav`
                 padding: 0;
                 cursor: pointer;
             }
+
+            /* DEFAULT STYLING*/
             .nav-item {
                 @apply --font-body;
                 margin: 0 16px;
@@ -62,20 +66,24 @@ Display an outline button item in the `kwc-nav`
                 height: 16px;
                 margin-right: 8px;
             }
-            .nav-item.deselected {
+
+            /* DESELECTED COLORS*/
+            .nav-item {
                 color: var(--color-grey);
             }
-            .nav-item.deselected:hover {
+            .nav-item:hover {
                 color: var(--color-stone);
             }
-            .nav-item.selected {
+
+            /* SELECTED COLORS*/
+            :host(.iron-selected) .nav-item {
                 color: var(--color-black);
             }
-            .nav-item.selected .icon {
+            :host(.iron-selected) .nav-item .icon {
                 color: var(--color-kano-orange);
             }
         </style>
-        <div class$="nav-item outline [[_activeClass]]">
+        <div class="nav-item outline">
             <dom-if>
                 <template is="dom-if" if="[[_hasIcon]]">
                     <iron-icon class="icon" icon="kano-icons:[[iconId]]"></iron-icon>
@@ -89,18 +97,9 @@ Display an outline button item in the `kwc-nav`
             is: 'kwc-nav-button',
             properties: {
                 /**
-                 * List of classes of host element. Without being a property
-                 * the element can't watch for changes and won't be able to
-                 * check if the `selectedClass` is contained.
-                 * @type {String}
-                 */
-                class: {
-                    type: String,
-                    reflectToAttribute: true
-                },
-                /**
-                 * CSS class name that the host should have to indicate wether
-                 * this component is selected or not.
+                 * CSS class name that the host should have to indicate whether
+                 * this component is selected or not. If this changes the
+                 * active state **styling won't work**.
                  * @type {String}
                  */
                 selectedClass: {
@@ -122,14 +121,6 @@ Display an outline button item in the `kwc-nav`
                 _hasIcon: {
                     type: Boolean,
                     computed: '_computeHasIcon(iconId)'
-                },
-                /**
-                 * Class to be appended on navigation item if it's active
-                 * @type {String}
-                 */
-                _activeClass: {
-                    type: String,
-                    computed: '_computeActiveClass(class)'
                 }
             },
             /**
@@ -139,18 +130,6 @@ Display an outline button item in the `kwc-nav`
              */
             _computeHasIcon (iconId) {
                 return iconId ? true : false;
-            },
-            /**
-             * Computes class to use if navigation item is active or not.
-             * @param {String} active Wether navigation is active or not.
-             * @return {String} Class to be used if navigation icon is selected
-             *     or not.
-             */
-            _computeActiveClass () {
-                let isSelected = this.classList.contains(
-                    this.selectedClass
-                );
-                return isSelected === true ? 'selected' : 'deselected';
             }
         });
     </script>

--- a/kwc-nav-item.html
+++ b/kwc-nav-item.html
@@ -15,7 +15,14 @@ Display a tab item in the `kwc-nav`
         <style>
             :host {
                 display: inline-block;
+                /**
+                 * This makes sure that it has a width before the slotted
+                 * content is loaded when there is no icon.
+                 */
+                min-width: 1px;
             }
+
+            /* SLOTTED CONTENT */
             .nav-item ::slotted(*) {
                 text-decoration: inherit;
                 font-family: inherit;
@@ -30,6 +37,8 @@ Display a tab item in the `kwc-nav`
                 padding: 0;
                 cursor: pointer;
             }
+
+            /* DEFAULT STYLING*/
             .nav-item {
                 @apply --font-body;
                 margin: 0 16px;
@@ -41,7 +50,6 @@ Display a tab item in the `kwc-nav`
                 text-transform: uppercase;
                 white-space: nowrap;
                 border: 0;
-                border-radius: 4px;
                 cursor: pointer;
                 background: transparent;
             }
@@ -53,20 +61,25 @@ Display a tab item in the `kwc-nav`
                 height: 16px;
                 margin-right: 8px;
             }
-            .nav-item.deselected {
+
+            /*DESELECTED*/
+            .nav-item {
                 color: var(--color-grey);
             }
-            .nav-item.deselected:hover {
+            .nav-item:hover {
                 color: var(--color-stone);
             }
-            .nav-item.selected {
+
+            /*SELECTED*/
+            :host(.iron-selected) .nav-item {
                 color: var(--color-white);
             }
-            .nav-item.selected .icon {
+            :host(.iron-selected) .nav-item .icon {
                 color: var(--color-kano-orange);
             }
+
         </style>
-        <div class$="nav-item [[_activeClass]]">
+        <div class="nav-item">
             <dom-if>
                 <template is="dom-if" if="[[_hasIcon]]">
                     <iron-icon class="icon" icon="kano-icons:[[iconId]]"></iron-icon>
@@ -80,18 +93,9 @@ Display a tab item in the `kwc-nav`
             is: 'kwc-nav-item',
             properties: {
                 /**
-                 * List of classes of host element. Without being a property
-                 * the element can't watch for changes and won't be able to
-                 * check if the `selectedClass` is contained.
-                 * @type {String}
-                 */
-                class: {
-                    type: String,
-                    reflectToAttribute: true
-                },
-                /**
                  * CSS class name that the host should have to indicate whether
-                 * this component is selected or not.
+                 * this component is selected or not. If this changes the
+                 * active state **styling won't work**.
                  * @type {String}
                  */
                 selectedClass: {
@@ -113,14 +117,6 @@ Display a tab item in the `kwc-nav`
                 _hasIcon: {
                     type: Boolean,
                     computed: '_computeHasIcon(iconId)'
-                },
-                /**
-                 * Class to be appended on navigation item if it's active
-                 * @type {String}
-                 */
-                _activeClass: {
-                    type: String,
-                    computed: '_computeActiveClass(class)'
                 }
             },
             /**
@@ -130,18 +126,6 @@ Display a tab item in the `kwc-nav`
              */
             _computeHasIcon (iconId) {
                 return iconId ? true : false;
-            },
-            /**
-             * Computes class to use if navigation item is active or not.
-             * @param {String} active Whether navigation is active or not.
-             * @return {String} Class to be used if navigation icon is selected
-             *     or not.
-             */
-            _computeActiveClass () {
-                let isSelected = this.classList.contains(
-                    this.selectedClass
-                );
-                return isSelected === true ? 'selected' : 'deselected';
             }
         });
     </script>

--- a/test/kwc-nav-item_test.html
+++ b/test/kwc-nav-item_test.html
@@ -48,18 +48,17 @@
                 assert.equal(element.is, 'kwc-nav-item');
             });
             test('not active by default', () => {
-                assert.equal(element._activeClass, 'deselected');
-                let navItem = Polymer.dom(element.root).querySelector('.nav-item');
-                assert.exists(navItem);
-                assert.isOk(navItem.classList.contains('deselected'));
-                assert.isNotOk(navItem.classList.contains('selected'));
+                assert.equal(
+                    element.classList.contains(element.selectedClass),
+                    false
+                );
             });
             test('without icon by default', (done) => {
                 assert.equal(element.iconId, null);
                 assert.equal(element._hasIcon, false);
                 flush(() => {
-                  let navItem = Polymer.dom(element.root).querySelector('.icon');
-                  assert.notExists(navItem);
+                  let icon = Polymer.dom(element.root).querySelector('.icon');
+                  assert.notExists(icon);
                   done();
                 });
             });
@@ -73,18 +72,17 @@
                 assert.equal(element.is, 'kwc-nav-item');
             });
             test('not active by default', () => {
-                assert.equal(element._activeClass, 'deselected');
-                let navItem = Polymer.dom(element.root).querySelector('.nav-item');
-                assert.exists(navItem);
-                assert.isOk(navItem.classList.contains('deselected'));
-                assert.isNotOk(navItem.classList.contains('selected'));
+                assert.equal(
+                    element.classList.contains(element.selectedClass),
+                    false
+                );
             });
             test('without icon by default', (done) => {
                 assert.equal(element.iconId, null);
                 assert.equal(element._hasIcon, false);
                 flush(() => {
-                  let navItem = Polymer.dom(element.root).querySelector('.icon');
-                  assert.notExists(navItem);
+                  let icon = Polymer.dom(element.root).querySelector('.icon');
+                  assert.notExists(icon);
                   done();
                 });
             });
@@ -98,18 +96,17 @@
                 assert.equal(element.is, 'kwc-nav-item');
             });
             test('not active by default', () => {
-                assert.equal(element._activeClass, 'deselected');
-                let navItem = Polymer.dom(element.root).querySelector('.nav-item');
-                assert.exists(navItem);
-                assert.isOk(navItem.classList.contains('deselected'));
-                assert.isNotOk(navItem.classList.contains('selected'));
+                assert.equal(
+                    element.classList.contains(element.selectedClass),
+                    false
+                );
             });
             test('with icon', (done) => {
                 assert.equal(element.iconId, 'challenges');
                 assert.equal(element._hasIcon, true);
                 flush(() => {
-                  let navItem = Polymer.dom(element.root).querySelector('.icon');
-                  assert.exists(navItem);
+                  let icon = Polymer.dom(element.root).querySelector('.icon');
+                  assert.exists(icon);
                   done();
                 });
             });
@@ -123,18 +120,17 @@
                 assert.equal(element.is, 'kwc-nav-item');
             });
             test('active item', () => {
-                assert.equal(element._activeClass, 'selected');
-                let navItem = Polymer.dom(element.root).querySelector('.nav-item');
-                assert.exists(navItem);
-                assert.isOk(navItem.classList.contains('selected'));
-                assert.isNotOk(navItem.classList.contains('deselected'));
+                assert.equal(
+                    element.classList.contains(element.selectedClass),
+                    true
+                );
             });
             test('without icon by default', (done) => {
                 assert.equal(element.iconId, undefined);
                 assert.equal(element._hasIcon, false);
                 flush(() => {
-                  let navItem = Polymer.dom(element.root).querySelector('.icon');
-                  assert.notExists(navItem);
+                  let icon = Polymer.dom(element.root).querySelector('.icon');
+                  assert.notExists(icon);
                   done();
                 });
             });
@@ -148,18 +144,17 @@
                 assert.equal(element.is, 'kwc-nav-item');
             });
             test('active item', () => {
-                assert.equal(element._activeClass, 'selected');
-                let navItem = Polymer.dom(element.root).querySelector('.nav-item');
-                assert.exists(navItem);
-                assert.isOk(navItem.classList.contains('selected'));
-                assert.isNotOk(navItem.classList.contains('deselected'));
+                assert.equal(
+                    element.classList.contains(element.selectedClass),
+                    true
+                );
             });
             test('with icon', (done) => {
                 assert.equal(element.iconId, 'challenges');
                 assert.equal(element._hasIcon, true);
                 flush(() => {
-                  let navItem = Polymer.dom(element.root).querySelector('.icon');
-                  assert.exists(navItem);
+                  let icon = Polymer.dom(element.root).querySelector('.icon');
+                  assert.exists(icon);
                   done();
                 });
             });


### PR DESCRIPTION
## Make sure the item has a width

When included on `kwc-nav`, the caret was being misplaced because it would calculate its position before the slotted content being loaded. This caused the flex box container ignore the existence of some items and messing with the offsets. By ensuring it will have a width it will calculate the caret position correctly. This is a problem that happened only on Safari.

## Remove `active` and `_activeClass`

This means the active styling will be based on the `:host` having the `.iron-selected` class. You can still change the `kwc-nav` selected class but it won’t affect the styling of this specific component.