### PR TITLE
Add link "behavior"

### DIFF
--- a/demo/index-button.html
+++ b/demo/index-button.html
@@ -54,6 +54,24 @@
             </template>
         </demo-snippet>
 
+        <h3>Behaving as a link with <code>_self</code> target</h3>
+        <demo-snippet>
+            <template>
+                <kwc-nav-button icon-id="challenges" href="#">
+                    Nav Item
+                </kwc-nav-button>
+            </template>
+        </demo-snippet>
+
+        <h3>Behaving as a link with <code>_blank</code> target</h3>
+        <demo-snippet>
+            <template>
+                <kwc-nav-button icon-id="challenges" href="http://kano.me" target="_blank">
+                    Nav Item
+                </kwc-nav-button>
+            </template>
+        </demo-snippet>
+
         <h3>With a link inside</h3>
         <demo-snippet>
             <template>

--- a/demo/index-item.html
+++ b/demo/index-item.html
@@ -64,6 +64,27 @@
             </template>
         </demo-snippet>
 
+        <h3>Behaving as a link with target <code>_self</code></h3>
+        <demo-snippet>
+            <template>
+                <div style="background: #394148;">
+                    <kwc-nav-item icon-id="challenges" href="#">
+                        Nav Item
+                    </kwc-nav-item>
+                </div>
+            </template>
+        </demo-snippet>
+        <h3>Behaving as a link with target <code>_blank</code></h3>
+        <demo-snippet>
+            <template>
+                <div style="background: #394148;">
+                    <kwc-nav-item icon-id="challenges" href="http://kano.me" target="_blank">
+                        Nav Item
+                    </kwc-nav-item>
+                </div>
+            </template>
+        </demo-snippet>
+
         <h3>With a link inside</h3>
         <demo-snippet>
             <template>

--- a/kwc-nav-button.html
+++ b/kwc-nav-button.html
@@ -137,7 +137,8 @@ Display an outline button item in the `kwc-nav`
                  */
                 target: {
                     type: String,
-                    value: '_self'
+                    value: '_self',
+                    reflectToAttribute: true
                 }
             },
             /**

--- a/kwc-nav-button.html
+++ b/kwc-nav-button.html
@@ -83,7 +83,7 @@ Display an outline button item in the `kwc-nav`
                 color: var(--color-kano-orange);
             }
         </style>
-        <div class="nav-item outline">
+        <div class="nav-item outline" on-tap="_navigate">
             <dom-if>
                 <template is="dom-if" if="[[_hasIcon]]">
                     <iron-icon class="icon" icon="kano-icons:[[iconId]]"></iron-icon>
@@ -121,6 +121,23 @@ Display an outline button item in the `kwc-nav`
                 _hasIcon: {
                     type: Boolean,
                     computed: '_computeHasIcon(iconId)'
+                },
+                /**
+                 * Link this element should point to.
+                 * @type {String}
+                 */
+                href: {
+                    type: String,
+                    value: null,
+                    reflectToAttribute: true
+                },
+                /**
+                 * Target for the link if it's behaving like it.
+                 * @type {String}
+                 */
+                target: {
+                    type: String,
+                    value: '_self'
                 }
             },
             /**
@@ -130,6 +147,11 @@ Display an outline button item in the `kwc-nav`
              */
             _computeHasIcon (iconId) {
                 return iconId ? true : false;
+            },
+            _navigate (e) {
+                if (this.href) {
+                    window.open(this.href, this.target);
+                }
             }
         });
     </script>

--- a/kwc-nav-item.html
+++ b/kwc-nav-item.html
@@ -79,7 +79,7 @@ Display a tab item in the `kwc-nav`
             }
 
         </style>
-        <div class="nav-item">
+        <div class="nav-item" on-tap="_navigate">
             <dom-if>
                 <template is="dom-if" if="[[_hasIcon]]">
                     <iron-icon class="icon" icon="kano-icons:[[iconId]]"></iron-icon>
@@ -117,6 +117,23 @@ Display a tab item in the `kwc-nav`
                 _hasIcon: {
                     type: Boolean,
                     computed: '_computeHasIcon(iconId)'
+                },
+                /**
+                 * Link this element should point to.
+                 * @type {String}
+                 */
+                href: {
+                    type: String,
+                    value: null,
+                    reflectToAttribute: true
+                },
+                /**
+                 * Target for the link if it's behaving like it.
+                 * @type {String}
+                 */
+                target: {
+                    type: String,
+                    value: '_self'
                 }
             },
             /**
@@ -126,6 +143,11 @@ Display a tab item in the `kwc-nav`
              */
             _computeHasIcon (iconId) {
                 return iconId ? true : false;
+            },
+            _navigate (e) {
+                if (this.href) {
+                    window.open(this.href, this.target);
+                }
             }
         });
     </script>

--- a/kwc-nav-item.html
+++ b/kwc-nav-item.html
@@ -133,7 +133,8 @@ Display a tab item in the `kwc-nav`
                  */
                 target: {
                     type: String,
-                    value: '_self'
+                    value: '_self',
+                    reflectToAttribute: true
                 }
             },
             /**


### PR DESCRIPTION
The most common use of this component apparently is the use of a link inside the navigation item and it causes problems such as not routing when not clicking exactly on the link.

One solution for this problem would be to style buttons and links inside the component but other solution would be make the entire navigation item behave like a link.

This PR includes a `href` and `target` properties to `kwc-nav-item` and `kwc-nav-button` so they can, optionally, behave like a link.

Also, I am duplicating both the `_navigate` method and properties because `kwc-nav-button` will become a "soft button" as described [here](https://projects.invisionapp.com/boards/D43CV9QURXP2V#/5639246/169743838). Just waiting for a more appropriate moment to do the change.