### PR TITLE
Routing without refresh

### DIFF
--- a/kwc-nav-button.html
+++ b/kwc-nav-button.html
@@ -150,9 +150,22 @@ Display an outline button item in the `kwc-nav`
             _computeHasIcon (iconId) {
                 return iconId ? true : false;
             },
+            /**
+             * Fired to simulate navigation event (link click) when navigation
+             * item is clicked.
+             *
+             * @event location-changed
+             */
+            /**
+             * Handles click on the navigation item and simulate a link click
+             * by pushing new state to history and firing `location-changed`
+             * event
+             * @param {Event} e Event object from tap event
+             */
             _navigate (e) {
                 if (this.href) {
-                    window.open(this.href, this.target);
+                    window.history.pushState({}, null, this.href);
+                    window.dispatchEvent(new CustomEvent('location-changed'));
                 }
             }
         });

--- a/kwc-nav-button.html
+++ b/kwc-nav-button.html
@@ -131,15 +131,6 @@ Display an outline button item in the `kwc-nav`
                     type: String,
                     value: null,
                     reflectToAttribute: true
-                },
-                /**
-                 * Target for the link if it's behaving like it.
-                 * @type {String}
-                 */
-                target: {
-                    type: String,
-                    value: '_self',
-                    reflectToAttribute: true
                 }
             },
             /**

--- a/kwc-nav-item.html
+++ b/kwc-nav-item.html
@@ -124,15 +124,6 @@ Display a tab item in the `kwc-nav`
                     type: String,
                     value: null,
                     reflectToAttribute: true
-                },
-                /**
-                 * Target for the link if it's behaving like it.
-                 * @type {String}
-                 */
-                target: {
-                    type: String,
-                    value: '_self',
-                    reflectToAttribute: true
                 }
             },
             /**

--- a/kwc-nav-item.html
+++ b/kwc-nav-item.html
@@ -143,9 +143,22 @@ Display a tab item in the `kwc-nav`
             _computeHasIcon (iconId) {
                 return iconId ? true : false;
             },
+            /**
+             * Fired to simulate navigation event (link click) when navigation
+             * item is clicked.
+             *
+             * @event location-changed
+             */
+            /**
+             * Handles click on the navigation item and simulate a link click
+             * by pushing new state to history and firing `location-changed`
+             * event
+             * @param {Event} e Event object from tap event
+             */
             _navigate (e) {
                 if (this.href) {
-                    window.open(this.href, this.target);
+                    window.history.pushState({}, null, this.href);
+                    window.dispatchEvent(new CustomEvent('location-changed'));
                 }
             }
         });


### PR DESCRIPTION
- Simulate link click without reload page
- Remove `target` property as it's not used