### PR TITLE
Change how the margin is calculated

### DIFF
--- a/kwc-nav-item.html
+++ b/kwc-nav-item.html
@@ -46,6 +46,10 @@ Custom property | Description | Default
                 cursor: pointer;
             }
 
+            .nav-item iron-icon ~ ::slotted(*) {
+                margin-left: 16px;
+            }
+
             /* DEFAULT STYLING*/
             .nav-item {
                 @apply --font-body;
@@ -67,7 +71,6 @@ Custom property | Description | Default
             .nav-item .icon {
                 width: 16px;
                 height: 16px;
-                margin-right: 8px;
             }
 
             /*DESELECTED*/


### PR DESCRIPTION
Allows the sizing of the button to remain correct if there is no label given (as on Kano World on small devices).

Part of the changes for this Trello card: https://trello.com/c/Duf5kL2m